### PR TITLE
changed global options for warnings and messages

### DIFF
--- a/Using_LIO_maps.Rmd
+++ b/Using_LIO_maps.Rmd
@@ -6,6 +6,11 @@ output:
   html_document:
     df_print: paged
 ---
+```{r, setup, include=FALSE}
+knitr::opts_chunk$set(message = FALSE)
+knitr::opts_chunk$set(warning = FALSE)
+```
+
 
 # Use a georeferenced TIF as a background
 
@@ -72,7 +77,7 @@ ggRGB(small_basemap, r = 1, g = 2, b = 3) +
 - See https://github.com/R-ArcGIS/r-bridge/issues/54  
 - Note that you must have an installation of ArcGIS Pro + ArcGIS Online account for this + install r-ArcGIS bridge.
 
-```{r}
+```{r arcbinding, eval=FALSE}
 library(arcgisbinding)
 arc.check_product()
 


### PR DESCRIPTION
Changed global options for warnings and messages. Left the arcbinding section in place but set eval=FALSE so that the markdown would run on most peoples systems without having arcgisbinding installed or operational.